### PR TITLE
Bump for latest version of crystal

### DIFF
--- a/src/heap/naive.cr
+++ b/src/heap/naive.cr
@@ -59,7 +59,7 @@ class Array(T)
 
     def heapify{{(arg == :min ? "" : "_max").id}}!
       # Transform list into a heap, in-place, in O(len(x)) time.
-      ((size/2 - 1)..0).each do |i|
+      ((size // 2 - 1)..0).each do |i|
         sift_up{{(arg == :min ? "" : "_max").id}}(i)
       end
       self


### PR DESCRIPTION
The shard wasn't working anymore with latest versions of crystal due to the `/` operator returning Floating point number. It is fixed now.